### PR TITLE
fix: Update iam_role_policy resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ module "rotator_lambda" {
 resource "aws_iam_role_policy" "rotator_lambda" {
   name   = "secrets-manager-access"
   policy = data.aws_iam_policy_document.rotator_lambda.json
-  role   = module.rotator_lambda.lambda_role_arn
+  role   = module.rotator_lambda.lambda_role_name
 }
 
 resource "aws_lambda_permission" "allow_secrets_manager" {


### PR DESCRIPTION
> 
> This is a fix for the role name requirement for aws_iam_role_policy
> ## Motivation and Context
> 
> terraform version 0.14.8
> Followed instructions as per terraform docs [database-credentials-rotator](https://registry.terraform.io/modules/jessiehernandez/database-credentials-rotator/aws/latest)
> ```
> Terraform will throw the following error during apply:
> [...]
> more similar module resources cut
> Acquiring state lock. This may take a few moments...
> module.database-credentials-rotator.aws_iam_role_policy.rotator_lambda: Destroying... [id=database-credentials-rotator:secretsManagerAccess]
> module.database-credentials-rotator.aws_iam_role_policy.rotator_lambda: Destruction complete after 1s
> module.database-credentials-rotator.aws_iam_role_policy.rotator_lambda: Creating...
> 
> Error: Error putting IAM role policy secretsManagerAccess: ValidationError: The specified value for roleName is invalid. It must contain only alphanumeric characters and/or the following: +=,.@_-
> 	status code: 400, request id: 6db38a23-b8f6-4e7f-8253-d31de6905b17
> 
>   on path/main.tf line 25, in resource "aws_iam_role_policy" "rotator_lambda":
>   25: resource "aws_iam_role_policy" "rotator_lambda" {
> ```
> 
> I needed a simple way to create a lambda function for rds credentials rotation. The only change was in passing role name instead of role arn.
> ## Breaking Changes
> 
> None
> ## How Has This Been Tested?
> 
>     * [x]  I have tested and validated these changes for few AWS resources.

